### PR TITLE
杀生樱伤害取决于释放时的主手武器伤害。杀生樱检查附近数量以增伤。限制3颗杀生樱。修改技能伤害。

### DIFF
--- a/scripts/components/yaemiko_skill.lua
+++ b/scripts/components/yaemiko_skill.lua
@@ -4,7 +4,13 @@ local yaemiko_skill = Class(function(self, inst)
 	self.inst = inst
 	self.attacker = inst
 
-	self.dmg = 30
+  --杀生樱与天狐显真的伤害倍率 可能需要平衡性调整
+	self.ssyDamageMultiply = {0.6,0.75,0.94} --一/二/三阶杀生樱伤害倍率 (空手时不到三阶连鸟都劈不死XD)
+  self.thxzDamageMultiply = {2.6,3.34} --天狐显真/天狐霆雷伤害倍率
+
+  self.ssyCreatorId = nil --释放本杀生樱的玩家uid/玩家uid
+
+	self.dmg = 10
 	self.mult = 1
 	self.bonus = 0
 
@@ -13,9 +19,30 @@ local yaemiko_skill = Class(function(self, inst)
 	self.sanity = false
 	self.spark = false
 	self.burn = false
-  self.ecnt = 3
+	
+	self.remainCnt = 14000 --杀生樱计时(以毫秒计)
+	
+	--玩家信息字段
+	
+	self.ecnt = 3 --玩家元素战技层数
 end)
 
+--获取杀生樱计时
+function yaemiko_skill:GetRemainCnt()
+	return self.remainCnt
+end
+
+--杀生樱计时前进100毫秒
+function yaemiko_skill:StepRemainCnt()
+	self.remainCnt = self.remainCnt - 100
+end
+
+--返回玩家UID
+function yaemiko_skill:GetUID()
+  return self.ssyCreatorId
+end
+
+--获取杀生樱基本伤害
 function yaemiko_skill:GetDamage()
 	if self.attacker.components.combat then
 		if self.attacker.components.combat.damagemultiplier ~= nil then
@@ -28,7 +55,16 @@ function yaemiko_skill:GetDamage()
 	return self.dmg * self.mult + self.bonus
 end
 
+--初始化杀生樱参数
+function yaemiko_skill:SsySetInit(creatorId,damage)
+  self.dmg = damage
+  self.ssyCreatorId = creatorId
+end
 
+--初始化神子参数
+function yaemiko_skill:MikoSetInit(uid)
+  self.ssyCreatorId = uid
+end
 
 function yaemiko_skill:chaozai(tgt,damage)
   local x,y,z=tgt.Transform:GetWorldPosition()
@@ -69,9 +105,30 @@ local CANT_TAGS = {"INLIMBO", "player", "chester", "companion","wall","abigail"}
 -- local LIGHTNINGSTRIKE_ONEOF_TAGS = { "lightningrod", "lightningtarget", "blows_air" }
 function yaemiko_skill:luolei()
 	local x, y, z = self.inst.Transform:GetWorldPosition()
-	local ents = TheSim:FindEntities(x, y, z, 12, nil, CANT_TAGS,nil)
+	local ents = TheSim:FindEntities(x, y, z, 14, nil, CANT_TAGS,nil)--杀生樱索敌距离
 	local damage = self:GetDamage()
+  local amtSsy = 0
 
+  --寻找附近杀生樱，距离4
+  local ssycnt = TheSim:FindEntities(x, y, z, 4, {"shashengying"}, nil,nil)
+  for i,v in pairs(ssycnt) do
+    --检查距离内同一玩家的杀生樱数量
+    if v.components.yaemiko_skill:GetUID()==self:GetUID() then
+      amtSsy = amtSsy + 1
+    end
+  end
+  --防止爆数量
+  if amtSsy >3 then
+    amtSsy = 3
+  --附近没找到同一玩家的杀生樱
+  --在落雷时如果此语句被触发必然是有BUG了
+  elseif amtSsy == 0 then
+    print("YaeMiko[ERROR]:Requested Luolei but cannot found Sessyouusakura created by player with userid:",self.inst.userid)
+    return false
+  end
+  
+  --乘算杀生樱伤害
+  damage = damage*self.ssyDamageMultiply[amtSsy]
 	-- if not target then
 	-- 	-- SpawnPrefab("thunder").Transform:SetPosition(x+math.random(-5, 5), y, z+math.random(-5, 5))
 	-- 	return
@@ -82,7 +139,8 @@ function yaemiko_skill:luolei()
     if v:HasTag("lightningrod") then
       SpawnPrefab("lightning").Transform:SetPosition(v.Transform:GetWorldPosition())
       v:PushEvent("lightningstrike")
-      return
+      --未有效命中
+      return false
     end
 		if v ~= self.inst and v:IsValid() and not v:IsInLimbo() then
 			if v.components.combat ~= nil and not (v.components.health ~= nil and v.components.health:IsDead()) then
@@ -94,8 +152,9 @@ function yaemiko_skill:luolei()
 
 	local tgt = GetRandomInstWithTag("yaemikotarget", self.inst, 12)
 	if tgt == nil then
-		-- SpawnPrefab("thunder").Transform:SetPosition(x+math.random(-5, 5), y, z+math.random(-5, 5))
-    return
+		--SpawnPrefab("thunder").Transform:SetPosition(x+math.random(-5, 5), y, z+math.random(-5, 5))
+    --未有效命中
+    return false
 	else
 		SpawnPrefab("lightning").Transform:SetPosition(tgt.Transform:GetWorldPosition())
 		-- self.attacker:AddTag("noenergy")
@@ -107,7 +166,8 @@ function yaemiko_skill:luolei()
     local players = FindPlayersInRange(x, y, z, 15,true)
     if players ~= nil then
       for i, v in pairs(players) do
-        if v then 
+        --寻找杀生樱的释放者，若找到则设置仇恨
+        if v and v.userid == self.ssyCreatorId then
           tgt.components.combat:SuggestTarget(v)
         end
       end
@@ -122,23 +182,26 @@ function yaemiko_skill:luolei()
 		end
     yaemiko_skill:FireCheck(tgt,damage)
 	end
+  --有效命中
+  return true
 end
 
-function yaemiko_skill:aoeQ()
-    local nearest = GetClosestInstWithTag({"hostile"}, self.inst, 12)
-    if nearest == nil then
-            -- inst.components.talker:Say("附近没有有趣的东西呢")
-        return
-    end
-        
-    self.inst.components.energy:DoDelta(-90)
-    local x, y, z = self.inst.Transform:GetWorldPosition()
-    local attackcnt=0
-    local ssycnt = TheSim:FindEntities(x, y, z, 12, {"shashengying"}, nil,nil)
-  
+function yaemiko_skill:aoeQ(damage)
+  local nearest = GetClosestInstWithTag({"hostile"}, self.inst, 12)
+  if nearest == nil then
+    -- inst.components.talker:Say("附近没有有趣的东西呢")
+    return
+  end
+       
+  self.inst.components.energy:DoDelta(-90)
+  local x, y, z = self.inst.Transform:GetWorldPosition()
+  local attackcnt=0
+  --寻找附近杀生樱，距离8
+  local ssycnt = TheSim:FindEntities(x, y, z, 8, {"shashengying"}, nil,nil)
   for i,v in pairs(ssycnt) do
-    if attackcnt<3 then
-      attackcnt=attackcnt+1
+    --检查距离内同一玩家的杀生樱数量
+    if v.components.yaemiko_skill:GetUID()==self.inst.userid then
+      attackcnt = attackcnt + 1
       v:DoTaskInTime(0,function(inst)
         if inst then
           local ix,iy,iz=inst.Transform:GetWorldPosition()
@@ -146,15 +209,14 @@ function yaemiko_skill:aoeQ()
           inst:Remove()
         end
       end)
-    else break
     end
   end
-
-  local damage=self:GetDamage()*1.5
-  --根据attackcnt召唤落雷。
-
+  --防止爆数量
+  if attackcnt >3 then
+    attackcnt = 3
+  end
+  --记录攻击发生位置
   x,y,z=nearest.Transform:GetWorldPosition()
-  
   
   --根据坐标范围伤害
   self.inst.sg:GoToState("cookbook_close")     
@@ -163,36 +225,37 @@ function yaemiko_skill:aoeQ()
     for i, v in pairs(ents) do
         if v:IsValid() and not v:IsInLimbo() then
           if v.components.combat ~= nil and not (v.components.health ~= nil and v.components.health:IsDead()) then
-            v.components.combat:GetAttacked(self.attacker, damage, nil, "electro")
+            v.components.combat:GetAttacked(self.attacker, damage*self.thxzDamageMultiply[1], nil, "electro")
             -- v.sg:GoToState("electrocute")
-            yaemiko_skill:FireCheck(v,damage)
+            yaemiko_skill:FireCheck(v,damage*self.thxzDamageMultiply[1])
 
           end
         end
     end
-
-  nearest.aoetask=nearest:DoPeriodicTask(0.3,function(nearest)
-    --闪电
-    local x1,y1,z1=nearest.Transform:GetWorldPosition()
-    SpawnPrefab("lightning").Transform:SetPosition(x1,y1,z1)
-    
-    --伤害
-    local ents = TheSim:FindEntities(x1, y1, z1, 3, nil, CANT_TAGS,nil)
-    for i, v in pairs(ents) do
+  --根据attackcnt召唤落雷。天狐霆雷会略晚于天狐显真发生
+  damage=damage*self.thxzDamageMultiply[2]
+  nearest:DoTaskInTime(0.5,function(nearest)
+    nearest.aoetask=nearest:DoPeriodicTask(0.3,function(nearest)
+      --闪电
+      local x1,y1,z1=nearest.Transform:GetWorldPosition()
+      SpawnPrefab("lightning").Transform:SetPosition(x1,y1,z1)
+      --伤害
+      local ents = TheSim:FindEntities(x1, y1, z1, 3, nil, CANT_TAGS,nil)
+      for i, v in pairs(ents) do
         if v:IsValid() and not v:IsInLimbo() then
           if v.components.combat ~= nil and not (v.components.health ~= nil and v.components.health:IsDead()) then
             v.components.combat:GetAttacked(self.attacker, damage, nil, "electro")
           end
-            yaemiko_skill:FireCheck(v,damage)
+          yaemiko_skill:FireCheck(v,damage)
         end
-    end
-
-  end)
-  nearest:DoTaskInTime(attackcnt/3,function(nearest)
-  if nearest.aoetask ~=nil then
-    nearest.aoetask:Cancel()
-    nearest.aoetask = nil
-  end
+      end
+    end)
+    nearest:DoTaskInTime(attackcnt/3,function(nearest)
+      if nearest.aoetask ~=nil then
+        nearest.aoetask:Cancel()
+        nearest.aoetask = nil
+      end
+    end)
   end)
 end
 

--- a/scripts/prefabs/yaemiko_fx.lua
+++ b/scripts/prefabs/yaemiko_fx.lua
@@ -42,30 +42,28 @@ local function summonssy()
 	inst.persists = false
 
 	inst:AddComponent("yaemiko_skill")
-  
-  inst:DoTaskInTime(0, function()
-		inst:DoPeriodicTask(3, function()
-			inst.components.yaemiko_skill:luolei()
-      --恢复元素能量
-      for i, v in ipairs(AllPlayers) do
-      if v.components.energy then
-        v.components.energy:DoDelta(1)
-      end
-
-	end
+		inst:DoPeriodicTask(0.1, function()
+		inst.components.yaemiko_skill:StepRemainCnt()
+		local remainCnt = inst.components.yaemiko_skill:GetRemainCnt()
+	  	if (remainCnt%3000) == 0 then
+			local flg = inst.components.yaemiko_skill:luolei()
+			--如果产生有效命中
+			if flg then
+			--恢复元素能量
+				for i, v in ipairs(AllPlayers) do
+					if v.components.energy then
+						v.components.energy:DoDelta(1)
+					end
+				end
+			end
+	  	end
+			if remainCnt <= 0 then
+				local ix,iy,iz=inst.Transform:GetWorldPosition()
+				SpawnPrefab("lightning_rod_fx").Transform:SetPosition(ix,iy-3,iz)
+				inst:Remove()
+			end
 		end)
-	end)
-  
-  inst:DoTaskInTime(12,function(inst)
-    if inst then
-      local ix,iy,iz=inst.Transform:GetWorldPosition()
-      SpawnPrefab("lightning_rod_fx").Transform:SetPosition(ix,iy-3,iz)
-      inst:Remove()
-    end
-  end)
-
 	return inst
-
 end
 
 return Prefab("shashengying",summonssy,assets)


### PR DESCRIPTION
杀生樱会记录释放它时玩家持有的武器伤害（无武器时为保底伤害）作为基准伤害。
杀生樱会统计附近同一玩家释放的杀生樱数量。
释放杀生樱后，若范围内存在同一玩家的其他杀生樱且超过3个，将销毁其中存在时间最短的杀生樱。
被杀生樱攻击的生物改为在一定范围内寻找释放杀生樱的玩家，若找到则附加仇恨。
天狐显真会忽略其他玩家释放的杀生樱。
杀生樱每次攻击造成的伤害基于保存的基准伤害，和释放时附近的杀生樱数量对应的伤害乘数。
天狐显真造成的伤害基于玩家持有的武器伤害（无武器时为保底伤害）和伤害乘数。