### PR TITLE
紫水晶强化御币

### DIFF
--- a/scripts/components/yaemikoyubistatus.lua
+++ b/scripts/components/yaemikoyubistatus.lua
@@ -1,0 +1,45 @@
+-- 御币信息类
+local yaemikoyubistatus = Class(function(self, inst)
+    self.inst = inst
+    self.refine = 1
+    self.damage = 20
+    -- 1阶基础伤害，每阶精炼增加伤害
+    -- 御币是电属性伤害，受1.5倍加成(潮湿目标2.5倍加成)，不建议面板伤害过高。技能伤害计算时会单独判断御币并乘上1.5的乘数
+    self.basedamage = 20
+    self.refineMultiply = 7.5
+end,
+nil,
+{
+})
+
+function yaemikoyubistatus:OnSave()
+    local data = {
+        refine = self.refine,
+        damage = self.damage
+    }
+    return data
+end
+
+function yaemikoyubistatus:OnLoad(data)
+    self.refine = data.refine or 1
+    self.damage = data.damage or 20
+    -- 保险起见还原伤害
+	self.inst.components.weapon:SetDamage(self.damage)
+end
+
+function yaemikoyubistatus:GetRefine()
+    return self.refine
+end
+
+function yaemikoyubistatus:RefineDoDelta(delta)
+    self.refine = self.refine + delta
+    if self.inst.components.weapon then
+        -- 目前想法是简单的线性伤害
+        self.damage = self.basedamage + (self.refine - 1) * self.refineMultiply
+        -- 更改伤害
+		self.inst.components.weapon:SetDamage(self.damage)
+    end
+    self.inst:PushEvent("RefineYaeMikoYubi")
+end
+
+return yaemikoyubistatus

--- a/scripts/prefabs/yaemiko.lua
+++ b/scripts/prefabs/yaemiko.lua
@@ -58,8 +58,13 @@ local function yaemiko_nowdamage(inst_f)
         local item = inst_f.components.inventory.equipslots[EQUIPSLOTS.HANDS]
         --有的模组武器damage是个函数，需要避免它是其他东西，防止(万一的)哪个奇怪武器伤害低于10
         if item and item.components.weapon and type(item.components.weapon.damage)=="number" and item.components.weapon.damage>10 then
-            --当主手持有武器，基准伤害为武器伤害 + 基本伤害
-            atkDamage = item.components.weapon.damage + TUNING.YAEMIKO_SKILL_DAMAGE_BASE
+            if item.prefab == "yubi" then
+                --当主手是御币 补偿1.5倍的伤害，基准伤害为武器伤害 + 基本伤害
+                atkDamage = item.components.weapon.damage * 1.5 + TUNING.YAEMIKO_SKILL_DAMAGE_BASE
+            else
+                --当主手持有非御币武器，基准伤害为武器伤害 + 基本伤害
+                atkDamage = item.components.weapon.damage + TUNING.YAEMIKO_SKILL_DAMAGE_BASE
+            end
         --奇奇怪怪模组武器的单独支持，尤其是原神相关
         elseif item and item.components.weapon and type(item.components.weapon.damage)=="function" then
             if item.prefab == "element_spear" then --元素反应：元素长矛

--- a/scripts/prefabs/yubi.lua
+++ b/scripts/prefabs/yubi.lua
@@ -11,6 +11,24 @@ local function onunequip(inst, owner)
     owner.AnimState:Show("ARM_normal")
 end
 
+-- 可以在考虑modinfo里配置强化上限以支持更高的强化(或禁止强化)，0为无限
+TUNING.YAEMIKO_YUBI_REFINE_LIMIT=5
+
+-- 进行精炼
+local function onRefine(inst, giver, item)
+    if TUNING.YAEMIKO_YUBI_REFINE_LIMIT == 0 or inst.components.yaemikoyubistatus:GetRefine()<TUNING.YAEMIKO_YUBI_REFINE_LIMIT then
+        inst.components.yaemikoyubistatus:RefineDoDelta(1)
+    end
+    inst.SoundEmitter:PlaySound("dontstarve/common/telebase_gemplace")
+end
+
+-- 判断给予的物品是否符合要求；是否现在还可以精炼
+local function canRefine(inst, item)
+    if item == nil or item.prefab ~= "purplegem" or (TUNING.YAEMIKO_YUBI_REFINE_LIMIT ~= 0 and inst.components.yaemikoyubistatus:GetRefine()>=TUNING.YAEMIKO_YUBI_REFINE_LIMIT) then
+        return false
+    end
+    return true
+end
 
 local function onattack_yubi(inst, attacker, target, skipsanity)
     -- if not skipsanity and attacker ~= nil then
@@ -90,7 +108,7 @@ local function fn()
     inst.components.inventoryitem.atlasname = "images/inventoryimages/yubi.xml"
 
     inst:AddComponent("weapon")
-    inst.components.weapon:SetDamage(30)
+    inst.components.weapon:SetDamage(20)
     inst.components.weapon:SetRange(8, 10)
     inst.components.weapon:SetOnAttack(onattack_yubi)
     inst.components.weapon:SetProjectile("yubi_projectile")
@@ -114,6 +132,12 @@ local function fn()
         owner.AnimState:Hide("ARM_normal")
     end)
     inst.components.equippable:SetOnUnequip(onunequip)
+
+    inst:AddComponent("yaemikoyubistatus")
+
+    inst:AddComponent("trader")
+    inst.components.trader:SetAbleToAcceptTest(canRefine)
+    inst.components.trader.onaccept = onRefine
 
     return inst
 end


### PR DESCRIPTION
紫水晶强化御币的实现。
下调了御币的基本伤害到20（电伤1.5倍，潮湿目标2.5倍，30的话1阶实际伤害保底45，这太高了）
计算技能伤害现在会单独判断御币，并将御币的基本伤害乘1.5作为武器伤害。